### PR TITLE
Fix declarations to be compatible with clang16

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -147,7 +147,7 @@ void hash_init(hash_table* _hash_array, hash_entry data[]) {
 }
 
 void hash_free(hash_table* tab,
-	       void (*func)()) {
+	       void (*func)(void*  data)) {
   int i;
   list* iter;
 

--- a/read-rl.c
+++ b/read-rl.c
@@ -98,7 +98,7 @@ static char** rl_esh_completion(const char* word, int start, int end) {
   }
 
   if (openparen(rl_line_buffer[start])) {
-    return rl_completion_matches(word, rl_find_builtin);
+    return rl_completion_matches(word, (rl_compentry_func_t *)rl_find_builtin);
 
   } else {
     return NULL;
@@ -109,7 +109,7 @@ void read_init(void) {
   rl_bind_key('\012', rl_literal_newline);
 
   /* rl_catch_signals = 0; */
-  rl_attempted_completion_function = rl_esh_completion;
+  rl_attempted_completion_function = (rl_completion_func_t *)rl_esh_completion;
 }
 
 char* read_read(char* prompt) {


### PR DESCRIPTION
Hi, 

you probably don't care at all, since this is unbelievable stale, but I wrote a patch for the gentoo repo so this works in clang16. 
By default clang16 will not allow old K&R style function declarations, implicit pointer conversions etc. 
Gentoo maintainers are currently going through their packages to fix the builds that still use these things in their C code. To mitigate the work across all the distros I try to push those changes upstream also. 
So, we still use http://slon.ttk.ru/esh/esh-0.8.5.tar.gz as the source for our package. But the site itself (http://slon.ttk.ru) is gone. So I can not push my changes upstream and I am afraid when this is gone completely your github repo here will be the only available source for this. 

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>